### PR TITLE
better delete feedback and sparql-query filtering

### DIFF
--- a/app/components/dataset-status.hbs
+++ b/app/components/dataset-status.hbs
@@ -2,8 +2,8 @@
   {{format-date this.task.created "dd/MM/yyyy 'at' HH:mm"}} - <TaskStatus @task={{this.task}} />
 {{else}}
   {{#if this.isDump}}
-    please init download
+    please start download
   {{else}}
-    please wait for the LDES-consumer-manager to initialize the download
+    LDES-consumer-manager manages LDES feed. Press button to start pipeline with already consumed data.
   {{/if}}
 {{/if}}

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -30,7 +30,7 @@
   </form.element>
   <form.element @controlType='label'>
     Tag paths
-    <small class='text-secondary'>(optional)</small><BsTooltip @placement="top">Configure paths
+    <small class='text-secondary'>(optional)</small><BsTooltip @renderInPlace={{true}} @placement="top">Configure paths
       to tags that can be used in the search filter.</BsTooltip></form.element>
 
   {{#each-in this.formModel.keywordFilter as |keywordPathKey|}}

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -96,28 +96,55 @@ FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true
         @pendingText="Testing..." />
     </div>
   </form.element>
-  {{#if (or this.filterCount (eq this.filterCount 0))}}
-    <BsAlert @type={{if (eq this.filterCount 0) "warning" "success"}}>
-      Counted {{this.filterCount}} entities.
-    </BsAlert>
-  {{/if}}
-  {{#if this.filterWarningMessage}}
-    <BsAlert @type="warning">
-      <:header>Warning</:header>
+  {{#each this.filterCountInputs as |filterInput| }}
+    {{#let (await (filter-count-input-get-task filterInput)) as |task|}}
+      <BsAlert @type="secondary" @onDismiss={{fn this.deleteModel filterInput}}>
+        <:header>
+          {{log task}}
+          Performing filter test...{{#if task}} <TaskStatus @task={{task}} @onTaskFinished={{this.reloadFilterIO}} /> {{/if}}
+        </:header>
+        <:body>
+          <dl>
+            <dt>Pivot entitiy:</dt>
+            <dd>{{filterInput.sourceClass}}</dd>
+            <dt>Label path:</dt>
+            <dd>{{filterInput.sourcePathString}}</dd>
+            <dt>SPARQL Filter:</dt>
+            <dd class="font-monospace">{{filterInput.sourceFilter}}</dd>
+          </dl>
+        </:body>
+      </BsAlert>
+    {{/let}}
+  {{/each}}
+  {{#each this.filterCountOutputs as |filterOutput| }}
+    <BsAlert @type={{filterOutput.status}} @onDismiss={{fn this.deleteModel filterOutput}}>
+      <:header>
+        Filter Test Result:
+      </:header>
       <:body>
-        {{this.filterWarningMessage}}
+        <dl>
+          {{#if (or filterOutput.count (eq filterOutput.count 0))}}
+            <dt>Count:</dt>
+            <dd>{{filterOutput.count}}</dd>
+          {{/if}}
+          {{#if filterOutput.warning}}
+            <dt>Warning:</dt>
+            <dd>{{filterOutput.warning}}</dd>
+          {{/if}}
+          {{#if filterOutput.error}}
+            <dt>Error:</dt>
+            <dd>{{filterOutput.error}}</dd>
+          {{/if}}
+          {{#if filterOutput.query}}
+            <details>
+              <summary class="fw-bold">Query:</summary>
+              <pre class="card card-body bg-light text-body mt-2">{{filterOutput.query}}</pre>
+            </details>
+          {{/if}}
+        </dl>
       </:body>
     </BsAlert>
-  {{/if}}
-  {{#unless this.filterValid}}
-    <BsAlert @type="danger">
-      <:header>Filter query failed!</:header>
-      <:body>
-        <p>{{this.filterErrorMessage}}</p>
-        <p> For count query: {{this.filterErroredQuery}}</p>
-      </:body>
-    </BsAlert>
-  {{/unless}}
+  {{/each}}
   <form.submitButton
     disabled={{or (not (and this.formModel.labelPath this.formModel.pivotType)) this.submit.isRunning}}
   >{{#if this.submit.isRunning}}Updating...{{else if @nodeShape}}Update{{else}}Submit{{/if}}</form.submitButton>

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -16,6 +16,14 @@
     <el.control @searchEnabled={{true}} required />
   </form.element>
   <form.element
+    @controlType='text'
+    @label='SPARQL filter query'
+    @property='filter'
+    as |el|
+  >
+    <el.control />
+  </form.element>
+  <form.element
     @controlType='power-select-multiple'
     @label='Label Path'
     @property='labelPath'

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -79,7 +79,7 @@
     @controlType='textarea'
     @label='SPARQL filter query'
     @property='filter'
-    @customError={{if this.filterMessage "Filter Query Failed"}}
+    @customError={{if this.filterErrorMessage "Filter Query Failed"}}
     @helpText="Enter a SPARQL expression to filter the entities before unifying them. The entitiy is available as variable ?entity."
     as |el|
   >
@@ -96,6 +96,14 @@ FILTER NOT EXISTS {?entity owl:deprecated &quot;true&quot;^^xsd:bool .}"
   {{#if (or this.filterCount (eq this.filterCount 0))}}
     <BsAlert @type={{if (eq this.filterCount 0) "warning" "success"}}>
       Counted {{this.filterCount}} entities.
+    </BsAlert>
+  {{/if}}
+  {{#if this.filterWarningMessage}}
+    <BsAlert @type="warning">
+      <:header>Warning</:header>
+      <:body>
+        {{this.filterWarningMessage}}
+      </:body>
     </BsAlert>
   {{/if}}
   {{#if (not this.filterValid)}}

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -88,9 +88,12 @@
       placeholder="# Enter a sparql query e.g.:
 FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true&quot; .}"
       />
-      <BsButton @outline={{true}} @type="success" @onClick={{this.testFilter}}>
-        Test
-      </BsButton>
+      <BsButton
+        @outline={{true}}
+        @type="success"
+        @onClick={{this.testFilter}}
+        @defaultText="Test"
+        @pendingText="Testing..." />
     </div>
   </form.element>
   {{#if (or this.filterCount (eq this.filterCount 0))}}

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -100,7 +100,6 @@ FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true
     {{#let (await (filter-count-input-get-task filterInput)) as |task|}}
       <BsAlert @type="secondary" @onDismiss={{fn this.deleteModel filterInput}}>
         <:header>
-          {{log task}}
           Performing filter test...{{#if task}} <TaskStatus @task={{task}} @onTaskFinished={{this.reloadFilterIO}} /> {{/if}}
         </:header>
         <:body>

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -110,7 +110,8 @@ FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true
     <BsAlert @type="danger">
       <:header>Filter query failed!</:header>
       <:body>
-        {{this.filterErrorMessage}}
+        <p>{{this.filterErrorMessage}}</p>
+        <p> For count query: {{this.filterErroredQuery}}</p>
       </:body>
     </BsAlert>
   {{/unless}}

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -80,13 +80,13 @@
     @label='SPARQL filter query'
     @property='filter'
     @customError={{if this.filterErrorMessage "Filter Query Failed"}}
-    @helpText="Enter a SPARQL expression to filter the entities before unifying them. The entitiy is available as variable ?entity."
+    @helpText="Enter a SPARQL expression to filter the entities before unifying them. Use full URIs without prefixes. The entity is available as variable ?entity. "
     as |el|
   >
     <div class="input-group">
       <el.control class="font-monospace"
       placeholder="# Enter a sparql query e.g.:
-FILTER NOT EXISTS {?entity owl:deprecated &quot;true&quot;^^xsd:bool .}"
+FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true&quot; .}"
       />
       <BsButton @outline={{true}} @type="success" @onClick={{this.testFilter}}>
         Test

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -106,14 +106,14 @@ FILTER NOT EXISTS {?entity <http://www.w3.org/2002/07/owl#deprecated> &quot;true
       </:body>
     </BsAlert>
   {{/if}}
-  {{#if (not this.filterValid)}}
+  {{#unless this.filterValid}}
     <BsAlert @type="danger">
       <:header>Filter query failed!</:header>
       <:body>
         {{this.filterErrorMessage}}
       </:body>
     </BsAlert>
-  {{/if}}
+  {{/unless}}
   <form.submitButton
     disabled={{or (not (and this.formModel.labelPath this.formModel.pivotType)) this.submit.isRunning}}
   >{{#if this.submit.isRunning}}Updating...{{else if @nodeShape}}Update{{else}}Submit{{/if}}</form.submitButton>

--- a/app/components/mapping-shape-creator.hbs
+++ b/app/components/mapping-shape-creator.hbs
@@ -16,14 +16,6 @@
     <el.control @searchEnabled={{true}} required />
   </form.element>
   <form.element
-    @controlType='text'
-    @label='SPARQL filter query'
-    @property='filter'
-    as |el|
-  >
-    <el.control />
-  </form.element>
-  <form.element
     @controlType='power-select-multiple'
     @label='Label Path'
     @property='labelPath'
@@ -83,6 +75,37 @@
       @searchEnabled={{true}}
     />
   </form.element>
+  <form.element
+    @controlType='textarea'
+    @label='SPARQL filter query'
+    @property='filter'
+    @customError={{if this.filterMessage "Filter Query Failed"}}
+    @helpText="Enter a SPARQL expression to filter the entities before unifying them. The entitiy is available as variable ?entity."
+    as |el|
+  >
+    <div class="input-group">
+      <el.control class="font-monospace"
+      placeholder="# Enter a sparql query e.g.:
+FILTER NOT EXISTS {?entity owl:deprecated &quot;true&quot;^^xsd:bool .}"
+      />
+      <BsButton @outline={{true}} @type="success" @onClick={{this.testFilter}}>
+        Test
+      </BsButton>
+    </div>
+  </form.element>
+  {{#if (or this.filterCount (eq this.filterCount 0))}}
+    <BsAlert @type={{if (eq this.filterCount 0) "warning" "success"}}>
+      Counted {{this.filterCount}} entities.
+    </BsAlert>
+  {{/if}}
+  {{#if (not this.filterValid)}}
+    <BsAlert @type="danger">
+      <:header>Filter query failed!</:header>
+      <:body>
+        {{this.filterErrorMessage}}
+      </:body>
+    </BsAlert>
+  {{/if}}
   <form.submitButton
     disabled={{or (not (and this.formModel.labelPath this.formModel.pivotType)) this.submit.isRunning}}
   >{{#if this.submit.isRunning}}Updating...{{else if @nodeShape}}Update{{else}}Submit{{/if}}</form.submitButton>

--- a/app/components/mapping-shape-creator.js
+++ b/app/components/mapping-shape-creator.js
@@ -52,14 +52,15 @@ class FormModel {
   }
 
   async testFilter(dataset) {
-    const params = new URLSearchParams({
-      "dataset_uri": dataset.uri,
-      "class": this.pivotType,
-      "source_path_string": createPropertyPathStr(this.labelPath),
-      "filter": this.filter,
-    });
+    let params = new FormData();
+    params.append("dataset_uri", dataset.uri);
+    params.append("class", this.pivotType);
+    params.append("source_path_string", createPropertyPathStr(this.labelPath));
+    params.append("filter", this.filter);
 
-    const res = await fetch(`/filter-count/?${params}`, {
+    const res = await fetch('/filter-count/', {
+      method: 'POST',
+      body: params,
       headers: {
         "Accept": "application/json"
       }

--- a/app/components/mapping-shape-creator.js
+++ b/app/components/mapping-shape-creator.js
@@ -36,6 +36,7 @@ class FormModel {
 
     this.labelPath = initValues.labelPath ?? null;
     this.pivotType = initValues.pivotType ?? null;
+    this.filter = initValues.filter ?? null;
 
     this.newKeywordPath = null;
 
@@ -92,6 +93,7 @@ export default class MappingShapeCreatorComponent extends Component {
     );
     this.formModel = new FormModel(pivotTypeOptions, labelPathOptions, {
       pivotType: this.nodeShape.targetClass,
+      filter: this.nodeShape.filter,
       labelPath: this.labelPropertyShape.path
         ? splitPropertyPathStr(this.labelPropertyShape.path)
         : null,
@@ -105,6 +107,7 @@ export default class MappingShapeCreatorComponent extends Component {
   @restartableTask
   *submit(params) {
     this.nodeShape.targetClass = params.pivotType;
+    this.nodeShape.filter = params.filter;
     this.labelPropertyShape.path = createPropertyPathStr(params.labelPath);
     // Remove all keyword properties before inserting the new ones
     this.nodeShape.propertyShapes

--- a/app/components/mapping-shape-creator.js
+++ b/app/components/mapping-shape-creator.js
@@ -82,6 +82,7 @@ export default class MappingShapeCreatorComponent extends Component {
   @tracked filterCount = null;
   @tracked filterValid = true;
   @tracked filterErrorMessage = '';
+  @tracked filterErroredQuery = '';
   @tracked filterWarningMessage = '';
 
   @service store;
@@ -137,11 +138,12 @@ export default class MappingShapeCreatorComponent extends Component {
       return;
     }
 
-    const { meta: { valid, count, error, warning }} = await res.json()
+    const { meta: { valid, count, error, query, warning }} = await res.json();
 
     this.filterValid = valid;
     this.filterCount = count;
     this.filterErrorMessage = error;
+    this.filterErroredQuery = query;
     this.filterWarningMessage = warning;
   }
 

--- a/app/components/mapping-shape-creator.js
+++ b/app/components/mapping-shape-creator.js
@@ -55,7 +55,7 @@ class FormModel {
     const params = new URLSearchParams({
       "dataset_uri": dataset.uri,
       "class": this.pivotType,
-      "source_path_string": this.labelPath,
+      "source_path_string": createPropertyPathStr(this.labelPath),
       "filter": this.filter,
     });
 
@@ -86,6 +86,15 @@ export default class MappingShapeCreatorComponent extends Component {
   @tracked filterWarningMessage = '';
 
   @service store;
+
+  get dataset() { return this.args.dataset; }
+
+  get filterCountInputs() {
+    return this.dataset.filterCountInputs.sortBy('created').reverse();
+  }
+  get filterCountOutputs() {
+    return this.dataset.filterCountOutputs.sortBy('created').reverse();
+  }
 
   @action
   async initializeData() {
@@ -132,19 +141,11 @@ export default class MappingShapeCreatorComponent extends Component {
     const res = await this.formModel.testFilter(this.args.dataset);
 
     if (!res.ok) {
-      this.filterValid = false;
-      this.filterErrorMessage = `Fatal Error: Could not test filter. Status code: ${res.status} ${res.statusText}. Please contact an administrator.`;
-      console.error("Could not test filter query, check the server! Response:\n",await res.text());
+      console.error("Could not test filter query, check the server! Response:\n", await res.text());
       return;
     }
 
-    const { meta: { valid, count, error, query, warning }} = await res.json();
-
-    this.filterValid = valid;
-    this.filterCount = count;
-    this.filterErrorMessage = error;
-    this.filterErroredQuery = query;
-    this.filterWarningMessage = warning;
+    this.args.dataset.filterCountInputs.reload()
   }
 
   @restartableTask
@@ -186,5 +187,20 @@ export default class MappingShapeCreatorComponent extends Component {
   @action
   removeKeywordFilter(key) {
     delete this.formModel.keywordFilter[key];
+  }
+
+  @action
+  deleteModel(model) {
+    model.destroyRecord();
+    // Return false to keep the alert open until the model is actually removed.
+    return false;
+  }
+
+  @action
+  reloadFilterIO() {
+    return Promise.all([
+      this.args.dataset.filterCountInputs.reload(),
+      this.args.dataset.filterCountOutputs.reload()
+    ])
   }
 }

--- a/app/components/mapping-shape-creator.js
+++ b/app/components/mapping-shape-creator.js
@@ -82,6 +82,7 @@ export default class MappingShapeCreatorComponent extends Component {
   @tracked filterCount = null;
   @tracked filterValid = true;
   @tracked filterErrorMessage = '';
+  @tracked filterWarningMessage = '';
 
   @service store;
 
@@ -136,11 +137,12 @@ export default class MappingShapeCreatorComponent extends Component {
       return;
     }
 
-    const { meta: { valid, count, error }} = await res.json()
+    const { meta: { valid, count, error, warning }} = await res.json()
 
     this.filterValid = valid;
     this.filterCount = count;
     this.filterErrorMessage = error;
+    this.filterWarningMessage = warning;
   }
 
   @restartableTask

--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -2,6 +2,7 @@ import Controller from '@ember/controller';
 import { service } from '@ember/service';
 import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
+
 export default class VocabulariesIndexController extends Controller {
   @service store;
   @service router;
@@ -20,6 +21,22 @@ export default class VocabulariesIndexController extends Controller {
     if (task.isSuccessful) {
       return this.refresh();
     }
+  }
+
+  @action
+  async restartTask(task) {
+    const now = new Date()
+    const newTask = this.store.createRecord('task', {
+      created: now,
+      modified: now,
+      status: 'http://redpencil.data.gift/id/concept/JobStatus/scheduled',
+      operation: task.operation,
+      index: task.index,
+      job: await task.job,
+      inputContainers: await task.inputContainers
+    });
+    await newTask.save();
+    this.router.refresh();
   }
 
   @action

--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -26,20 +26,11 @@ export default class VocabulariesIndexController extends Controller {
   @action
   async refresh() {
     this.router.refresh();
-    await vocabulary.destroyRecord();
-    this.router.refresh();
-  }
-
-  @action
-  async handleDeleteTaskFinished(task) {
-    if (task.isSuccessful) {
-      return this.refresh();
-    }
   }
 
   @action
   async restartTask(task) {
-    const now = new Date()
+    const now = new Date();
     const newTask = this.store.createRecord('task', {
       created: now,
       modified: now,
@@ -47,14 +38,9 @@ export default class VocabulariesIndexController extends Controller {
       operation: task.operation,
       index: task.index,
       job: await task.job,
-      inputContainers: await task.inputContainers
+      inputContainers: await task.inputContainers,
     });
     await newTask.save();
-    this.router.refresh();
-  }
-
-  @action
-  async refresh() {
     this.router.refresh();
   }
 }

--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -43,12 +43,4 @@ export default class VocabulariesIndexController extends Controller {
     await newTask.save();
     this.router.refresh();
   }
-<<<<<<< HEAD
-
-  @action
-  async refresh() {
-    await this.router.refresh();
-  }
-=======
->>>>>>> origin/master
 }

--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -33,7 +33,7 @@ export default class VocabulariesIndexController extends Controller {
   @action
   async handleDeleteTaskFinished(task) {
     if (task.isSuccessful) {
-      return this.refresh();
+      await this.router.refresh();
     }
   }
 
@@ -55,6 +55,6 @@ export default class VocabulariesIndexController extends Controller {
 
   @action
   async refresh() {
-    this.router.refresh();
+    await this.router.refresh();
   }
 }

--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -16,6 +16,13 @@ export default class VocabulariesIndexController extends Controller {
   }
 
   @action
+  async handleDeleteTaskFinished(task) {
+    if (task.isSuccessful) {
+      return this.refresh();
+    }
+  }
+
+  @action
   async refresh() {
     this.router.refresh();
   }

--- a/app/controllers/vocabularies/index.js
+++ b/app/controllers/vocabularies/index.js
@@ -4,12 +4,19 @@ import { action } from '@ember/object';
 import { tracked } from '@glimmer/tracking';
 export default class VocabulariesIndexController extends Controller {
   @service store;
+  @service router;
   @tracked sort = ':no-case:name';
   @tracked page = 0;
   @tracked size = 20;
 
   @action
   async deleteVocab(vocabulary) {
-    vocabulary.destroyRecord();
+    await vocabulary.destroyRecord();
+    this.router.refresh();
+  }
+
+  @action
+  async refresh() {
+    this.router.refresh();
   }
 }

--- a/app/controllers/vocabulary/vocabulary-mapping-and-unification.js
+++ b/app/controllers/vocabulary/vocabulary-mapping-and-unification.js
@@ -45,8 +45,8 @@ export default class VocabularyMappingAndUnificationController extends Controlle
       // Task finished -> look for metadata
       if (!this.hasMeta) {
         while (!isPresent(this.model.dataset.classes)) {
-          console.log("Waiting for metadata to appear...")
-          yield timeout(5000);
+          console.log('Waiting for metadata to appear...');
+          yield timeout(3000);
           yield this.model.dataset.classes.reload();
         }
         this.send('reloadModel');

--- a/app/helpers/filter-count-input-get-task.js
+++ b/app/helpers/filter-count-input-get-task.js
@@ -1,0 +1,10 @@
+import GetTaskByInputAndOperation from "./get-task-by-input-and-operation";
+
+export default class FilterCountInputGetTask extends GetTaskByInputAndOperation {
+  compute([filterCountInput]) {
+    return super.compute([filterCountInput], {
+      operation: 'http://mu.semte.ch/vocabularies/ext/FilterCountJob',
+    });
+  }
+}
+

--- a/app/helpers/get-task-by-input-and-operation.js
+++ b/app/helpers/get-task-by-input-and-operation.js
@@ -1,11 +1,17 @@
 import Helper from '@ember/component/helper';
 import { inject as service } from '@ember/service';
 
-export default class GetTaskByInputAndOperation extends Helper{
+export default class GetTaskByInputAndOperation extends Helper {
   @service store;
 
   async compute([input], { operation }) {
-    const tasks = await this.store.query('task', {
+    return getTaskByInputAndOperation(this.store, input, operation);
+  }
+
+}
+
+export async function getTaskByInputAndOperation(store, input, operation) {
+    const tasks = await store.query('task', {
       'filter[input-containers][content]': input.uri,
       'filter[operation]': operation,
       sort: '-created',
@@ -13,4 +19,3 @@ export default class GetTaskByInputAndOperation extends Helper{
     });
     return tasks[0];
   }
-}

--- a/app/helpers/get-task-by-input-and-operation.js
+++ b/app/helpers/get-task-by-input-and-operation.js
@@ -1,0 +1,16 @@
+import Helper from '@ember/component/helper';
+import { inject as service } from '@ember/service';
+
+export default class GetTaskByInputAndOperation extends Helper{
+  @service store;
+
+  async compute([input], { operation }) {
+    const tasks = await this.store.query('task', {
+      'filter[input-containers][content]': input.uri,
+      'filter[operation]': operation,
+      sort: '-created',
+      'page[size]': 1
+    });
+    return tasks[0];
+  }
+}

--- a/app/helpers/get-task-by-input-and-operation.js
+++ b/app/helpers/get-task-by-input-and-operation.js
@@ -7,15 +7,14 @@ export default class GetTaskByInputAndOperation extends Helper {
   async compute([input], { operation }) {
     return getTaskByInputAndOperation(this.store, input, operation);
   }
-
 }
 
 export async function getTaskByInputAndOperation(store, input, operation) {
-    const tasks = await store.query('task', {
-      'filter[input-containers][content]': input.uri,
-      'filter[operation]': operation,
-      sort: '-created',
-      'page[size]': 1
-    });
-    return tasks[0];
-  }
+  const tasks = await store.query('task', {
+    'filter[input-containers][content]': input.uri,
+    'filter[operation]': operation,
+    sort: '-created',
+    'page[size]': 1,
+  });
+  return tasks[0];
+}

--- a/app/helpers/vocab-get-delete-waiting-task.js
+++ b/app/helpers/vocab-get-delete-waiting-task.js
@@ -1,0 +1,10 @@
+import GetTaskByInputAndOperation from "./get-task-by-input-and-operation";
+
+export default class VocabGetDeleteWaitingTask extends GetTaskByInputAndOperation {
+
+  compute([vocab]) {
+    return super.compute([vocab], {
+      operation: 'http://mu.semte.ch/vocabularies/ext/VocabDeleteWaitJob'
+    })
+  }
+}

--- a/app/helpers/vocab-get-delete-waiting-task.js
+++ b/app/helpers/vocab-get-delete-waiting-task.js
@@ -1,10 +1,9 @@
-import GetTaskByInputAndOperation from "./get-task-by-input-and-operation";
+import GetTaskByInputAndOperation from './get-task-by-input-and-operation';
 
 export default class VocabGetDeleteWaitingTask extends GetTaskByInputAndOperation {
-
   compute([vocab]) {
     return super.compute([vocab], {
-      operation: 'http://mu.semte.ch/vocabularies/ext/VocabDeleteWaitJob'
-    })
+      operation: 'http://mu.semte.ch/vocabularies/ext/VocabDeleteWaitJob',
+    });
   }
 }

--- a/app/helpers/vocab-get-deleting-task.js
+++ b/app/helpers/vocab-get-deleting-task.js
@@ -1,0 +1,10 @@
+import GetTaskByInputAndOperation from "./get-task-by-input-and-operation";
+
+export default class VocabGetDeletingTask extends GetTaskByInputAndOperation {
+
+  compute([vocab]) {
+    return super.compute([vocab], {
+      operation: 'http://mu.semte.ch/vocabularies/ext/VocabDeleteJob'
+    })
+  }
+}

--- a/app/helpers/vocab-get-deleting-task.js
+++ b/app/helpers/vocab-get-deleting-task.js
@@ -1,10 +1,9 @@
-import GetTaskByInputAndOperation from "./get-task-by-input-and-operation";
+import GetTaskByInputAndOperation from './get-task-by-input-and-operation';
 
 export default class VocabGetDeletingTask extends GetTaskByInputAndOperation {
-
   compute([vocab]) {
     return super.compute([vocab], {
-      operation: 'http://mu.semte.ch/vocabularies/ext/VocabDeleteJob'
-    })
+      operation: 'http://mu.semte.ch/vocabularies/ext/VocabDeleteJob',
+    });
   }
 }

--- a/app/helpers/vocab-is-delete-waiting.js
+++ b/app/helpers/vocab-is-delete-waiting.js
@@ -1,0 +1,9 @@
+import VocabGetDeleteWaitingTask from "./vocab-get-delete-waiting-task"
+
+export default class VocabIsDeleteWaiting extends VocabGetDeleteWaitingTask {
+
+  async compute([vocab]) {
+    const task = await super.compute([vocab])
+    return task && !task.hasEnded
+  }
+}

--- a/app/helpers/vocab-is-delete-waiting.js
+++ b/app/helpers/vocab-is-delete-waiting.js
@@ -4,6 +4,6 @@ export default class VocabIsDeleteWaiting extends VocabGetDeleteWaitingTask {
 
   async compute([vocab]) {
     const task = await super.compute([vocab])
-    return task && !task.hasEnded
+    return task && !task.isSuccessful
   }
 }

--- a/app/helpers/vocab-is-delete-waiting.js
+++ b/app/helpers/vocab-is-delete-waiting.js
@@ -1,9 +1,8 @@
-import VocabGetDeleteWaitingTask from "./vocab-get-delete-waiting-task"
+import VocabGetDeleteWaitingTask from './vocab-get-delete-waiting-task';
 
 export default class VocabIsDeleteWaiting extends VocabGetDeleteWaitingTask {
-
   async compute([vocab]) {
-    const task = await super.compute([vocab])
-    return task && !task.isSuccessful
+    const task = await super.compute([vocab]);
+    return task && !task.isSuccessful;
   }
 }

--- a/app/helpers/vocab-is-deleting.js
+++ b/app/helpers/vocab-is-deleting.js
@@ -1,9 +1,8 @@
-import VocabGetDeletingTask from "./vocab-get-deleting-task"
+import VocabGetDeletingTask from './vocab-get-deleting-task';
 
 export default class VocabIsDeleting extends VocabGetDeletingTask {
-
   async compute([vocab]) {
-    const task = await super.compute([vocab])
-    return task && !task.isSuccessful
+    const task = await super.compute([vocab]);
+    return task && !task.isSuccessful;
   }
 }

--- a/app/helpers/vocab-is-deleting.js
+++ b/app/helpers/vocab-is-deleting.js
@@ -4,6 +4,6 @@ export default class VocabIsDeleting extends VocabGetDeletingTask {
 
   async compute([vocab]) {
     const task = await super.compute([vocab])
-    return task && !task.hasEnded
+    return task && !task.isSuccessful
   }
 }

--- a/app/helpers/vocab-is-deleting.js
+++ b/app/helpers/vocab-is-deleting.js
@@ -1,0 +1,9 @@
+import VocabGetDeletingTask from "./vocab-get-deleting-task"
+
+export default class VocabIsDeleting extends VocabGetDeletingTask {
+
+  async compute([vocab]) {
+    const task = await super.compute([vocab])
+    return task && !task.hasEnded
+  }
+}

--- a/app/models/data-container.js
+++ b/app/models/data-container.js
@@ -1,7 +1,9 @@
-import Model, { attr } from '@ember-data/model';
+import Model, { attr, hasMany } from '@ember-data/model';
 
 export default class DataContainerModel extends Model {
   @attr('string') uri;
   @attr('string-set') content;
   // @hasMany('file', { async: true, inverse: 'dataContainer' }) files;
+
+  @hasMany('task', { inverse: 'inputContainers' }) inputFromTasks;
 }

--- a/app/models/dataset.js
+++ b/app/models/dataset.js
@@ -19,5 +19,8 @@ export default class Dataset extends Model {
   @hasMany('dataset', { inverse: null }) classes;
   @hasMany('dataset', { inverse: null }) properties;
 
+  @hasMany('filter-count-input', {inverse: 'dataset'}) filterCountInputs;
+  @hasMany('filter-count-output', {inverse: 'dataset'}) filterCountOutputs;
+
   @belongsTo('vocabulary') vocabulary;
 }

--- a/app/models/filter-count-input.js
+++ b/app/models/filter-count-input.js
@@ -1,0 +1,14 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class FilterCountInputModel extends Model {
+  @attr('string') uri;
+
+  @attr('datetime') created;
+  @attr('datetime') modified;
+
+  @attr('string') sourceClass;
+  @attr('string') sourcePathString;
+  @attr('string') sourceFilter;
+
+  @belongsTo('dataset', {inverse: 'filterCountInputs'}) dataset;
+}

--- a/app/models/filter-count-output.js
+++ b/app/models/filter-count-output.js
@@ -1,0 +1,26 @@
+import Model, { attr, belongsTo } from '@ember-data/model';
+
+export default class FilterCountOutputModel extends Model {
+  @attr('string') uri;
+
+  @attr('datetime') created;
+  @attr('datetime') modified;
+
+  @attr('string') query;
+  @attr('boolean') valid;
+  @attr('number') count;
+  @attr('string') warning;
+  @attr('string') error;
+
+  @belongsTo('dataset', {inverse: 'filterCountOutputs'}) dataset;
+
+  get status() {
+    if (this.error || !this.valid) {
+      return 'danger';
+    } else if (this.warning || this.count === 0) {
+      return 'warning';
+    } else {
+      return 'success';
+    }
+  }
+}

--- a/app/models/shacl-node-shape.js
+++ b/app/models/shacl-node-shape.js
@@ -2,6 +2,7 @@ import Model, { attr, belongsTo, hasMany } from '@ember-data/model';
 
 export default class ShaclNodeShape extends Model {
   @attr uri;
+  @attr('string') filter;
 
   @attr targetClass;
   @hasMany('shacl-property-shape') propertyShapes;

--- a/app/models/task.js
+++ b/app/models/task.js
@@ -15,7 +15,7 @@ export default class TaskModel extends Model {
 
   //Due to lack of inheritance in mu-cl-resource, we directly link to file and collection, stuff we need here.
   @hasMany('data-container', { async: true, inverse: null }) resultsContainers;
-  @hasMany('data-container', { async: true, inverse: null }) inputContainers;
+  @hasMany('data-container', { async: true, inverse: 'inputFromTasks' }) inputContainers;
 
   //TODO: move this later to a propery modeled skos:Conceptscheme from backend
   statusesMap = {

--- a/app/models/vocabulary.js
+++ b/app/models/vocabulary.js
@@ -12,38 +12,4 @@ export default class VocabularyModel extends Model {
   @hasMany('dataset') sourceDatasets;
   @belongsTo('shacl-node-shape') mappingShape;
   @hasMany('data-container') dataContainers;
-
-  get deleting() {
-    return this.deletingTask.then((t) => t && !t.hasEnded)
-  }
-  get deletingTask() {
-    return this._getDeletingTask()
-  }
-
-  get deleteWaiting() {
-    return this.deleteWaitingTask.then((t) => t && !t.hasEnded)
-  }
-  get deleteWaitingTask() {
-    return this._getDeleteWaitingTask()
-  }
-
-  async _getDeletingTask() {
-    const tasks = await this.store.query('task', {
-      'filter[input-containers][content]': this.uri,
-      'filter[operation]': 'http://mu.semte.ch/vocabularies/ext/VocabDeleteJob',
-      sort: '-created',
-      'page[size]': 1
-    })
-    return tasks.firstObject
-  }
-
-  async _getDeleteWaitingTask() {
-    const tasks = await this.store.query('task', {
-      'filter[input-containers][content]': this.uri,
-      'filter[operation]': 'http://mu.semte.ch/vocabularies/ext/VocabDeleteWaitJob',
-      sort: '-created',
-      'page[size]': 1
-    })
-    return tasks.firstObject
-  }
 }

--- a/app/models/vocabulary.js
+++ b/app/models/vocabulary.js
@@ -8,4 +8,22 @@ export default class VocabularyModel extends Model {
 
   @hasMany('dataset') sourceDatasets;
   @belongsTo('shacl-node-shape') mappingShape;
+  @hasMany('data-container') dataContainers;
+
+  get deleting() {
+    return this.deletingTask
+  }
+  get deletingTask() {
+    return this._getDeletingTask()
+  }
+
+  async _getDeletingTask() {
+    const dataContainers = await this.dataContainers
+    const tasks = await Promise.all(dataContainers.map((dc) => dc.inputFromTasks))
+
+    return tasks.flat().find((task) => {
+      console.log(task.operation)
+      return task.operation === 'http://mu.semte.ch/vocabularies/ext/VocabDeleteJob'
+    })
+  }
 }

--- a/app/routes/vocabularies/index.js
+++ b/app/routes/vocabularies/index.js
@@ -19,6 +19,7 @@ export default class VocabulariesIndexRoute extends Route {
         number: params.page,
         size: params.size,
       },
+      include: 'data-containers.input-from-tasks'
     };
 
     if (params.filter) {

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -35,6 +35,11 @@
             {{! `task` is null while we await }}
               {{#if task}}
                 Deleting <TaskStatus @task={{task}} @onTaskFinished={{this.handleDeleteTaskFinished}} />
+                <BsButton
+                  @type='danger'
+                  @onClick={{fn this.restartTask task}}>
+                  Try Again
+                </BsButton>
               {{/if}}
             {{/let}}
           {{else if waiting}}
@@ -42,6 +47,11 @@
             {{! `task` is null while we await }}
               {{#if task}}
                 Waiting for search <TaskStatus @task={{task}} @onTaskFinished={{this.handleDeleteTaskFinished}} />
+                <BsButton
+                  @type='danger'
+                  @onClick={{fn this.restartTask task}}>
+                  Try Again
+                </BsButton>
               {{/if}}
             {{/let}}
           {{else}}

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -44,7 +44,6 @@
               <:message>
                 <p>Are you sure you want to delete vocabulary
                   <strong>{{vocab.name}}</strong>?<br><br>
-                  <i>Note that deleting large vocabularies may take a long time. Make sure to refresh the page manually.</i>
                 </p>
               </:message>
               <:buttonContent>

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -25,22 +25,26 @@
         <LinkTo @route='vocabulary' @model={{vocab.id}}>{{vocab.name}}</LinkTo>
       </td>
       <td>
-        <ConfirmationButton
-          @onConfirm={{fn this.deleteVocab vocab}}
-          @confirmBtnTxt='Delete'
-          @confirmBtnType='danger'
-          @type='danger'
-        >
-          <:message>
-            <p>Are you sure you want to delete vocabulary
-              <strong>{{vocab.name}}</strong>?<br><br>
-              <i>Note that deleting large vocabularies may take a long time. Make sure to refresh the page manually.</i>
-            </p>
-          </:message>
-          <:buttonContent>
-            <BsIcon @name='trash-fill' />
-          </:buttonContent>
-        </ConfirmationButton>
+        {{#if (await vocab.deleting)}}
+          Deleting <TaskStatus @task={{await vocab.deletingTask}} @onTaskFinished={{action 'refresh'}} />
+        {{else}}
+          <ConfirmationButton
+            @onConfirm={{fn this.deleteVocab vocab}}
+            @confirmBtnTxt='Delete'
+            @confirmBtnType='danger'
+            @type='danger'
+          >
+            <:message>
+              <p>Are you sure you want to delete vocabulary
+                <strong>{{vocab.name}}</strong>?<br><br>
+                <i>Note that deleting large vocabularies may take a long time. Make sure to refresh the page manually.</i>
+              </p>
+            </:message>
+            <:buttonContent>
+              <BsIcon @name='trash-fill' />
+            </:buttonContent>
+          </ConfirmationButton>
+        {{/if}}
       </td>
       <td>
         <VocabAlias @vocab={{vocab}}/>

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -21,7 +21,7 @@
       <th>Alias</th>
     </Content.header>
     <Content.body as |vocab|>
-      {{#let (await vocab.deleting) (await vocab.deleteWaiting) as | deleting waiting | }}
+      {{#let (await (vocab-is-deleting vocab)) (await (vocab-is-delete-waiting vocab)) as | deleting waiting | }}
         <td>
           {{#if (or deleting waiting)}}
             {{vocab.name}}
@@ -31,9 +31,9 @@
         </td>
         <td>
           {{#if deleting}}
-            Deleting <TaskStatus @task={{await vocab.deletingTask}} @onTaskFinished={{this.refresh}} />
+            Deleting <TaskStatus @task={{await (vocab-get-deleting-task vocab)}} @onTaskFinished={{this.refresh}} />
           {{else if waiting}}
-            Waiting for search <TaskStatus @task={{await vocab.deleteWaitingTask}} @onTaskFinished={{this.refresh}} />
+            Waiting for search <TaskStatus @task={{await (vocab-get-delete-waiting-task vocab)}} @onTaskFinished={{this.refresh}} />
           {{else}}
             <ConfirmationButton
               @onConfirm={{fn this.deleteVocab vocab}}

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -21,34 +21,44 @@
       <th>Alias</th>
     </Content.header>
     <Content.body as |vocab|>
-      <td>
-        <LinkTo @route='vocabulary' @model={{vocab.id}}>{{vocab.name}}</LinkTo>
-      </td>
-      <td>
-        {{#if (await vocab.deleting)}}
-          Deleting <TaskStatus @task={{await vocab.deletingTask}} @onTaskFinished={{action 'refresh'}} />
-        {{else}}
-          <ConfirmationButton
-            @onConfirm={{fn this.deleteVocab vocab}}
-            @confirmBtnTxt='Delete'
-            @confirmBtnType='danger'
-            @type='danger'
-          >
-            <:message>
-              <p>Are you sure you want to delete vocabulary
-                <strong>{{vocab.name}}</strong>?<br><br>
-                <i>Note that deleting large vocabularies may take a long time. Make sure to refresh the page manually.</i>
-              </p>
-            </:message>
-            <:buttonContent>
-              <BsIcon @name='trash-fill' />
-            </:buttonContent>
-          </ConfirmationButton>
-        {{/if}}
-      </td>
-      <td>
-        <VocabAlias @vocab={{vocab}}/>
-      </td>
+      {{#let (await vocab.deleting) (await vocab.deleteWaiting) as | deleting waiting | }}
+        <td>
+          {{#if (or deleting waiting)}}
+            {{vocab.name}}
+          {{else}}
+            <LinkTo @route='vocabulary' @model={{vocab.id}}>{{vocab.name}}</LinkTo>
+          {{/if}}
+        </td>
+        <td>
+          {{#if deleting}}
+            Deleting <TaskStatus @task={{await vocab.deletingTask}} @onTaskFinished={{action 'refresh'}} />
+          {{else if waiting}}
+            Waiting for search <TaskStatus @task={{await vocab.deleteWaitingTask}} @onTaskFinished={{action 'refresh'}} />
+          {{else}}
+            <ConfirmationButton
+              @onConfirm={{fn this.deleteVocab vocab}}
+              @confirmBtnTxt='Delete'
+              @confirmBtnType='danger'
+              @type='danger'
+            >
+              <:message>
+                <p>Are you sure you want to delete vocabulary
+                  <strong>{{vocab.name}}</strong>?<br><br>
+                  <i>Note that deleting large vocabularies may take a long time. Make sure to refresh the page manually.</i>
+                </p>
+              </:message>
+              <:buttonContent>
+                <BsIcon @name='trash-fill' />
+              </:buttonContent>
+            </ConfirmationButton>
+          {{/if}}
+        </td>
+        <td>
+          {{#if (not (or deleting waiting))}}
+            <VocabAlias @vocab={{vocab}}/>
+          {{/if}}
+        </td>
+      {{/let}}
     </Content.body>
   </Table.content>
 </DataTable>

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -34,14 +34,14 @@
             {{#let (await (vocab-get-deleting-task vocab)) as | task |}}
             {{! `task` is null while we await }}
               {{#if task}}
-                Deleting <TaskStatus @task={{task}} @onTaskFinished={{this.refresh}} />
+                Deleting <TaskStatus @task={{task}} @onTaskFinished={{this.handleDeleteTaskFinished}} />
               {{/if}}
             {{/let}}
           {{else if waiting}}
             {{#let (await (vocab-get-delete-waiting-task vocab)) as | task |}}
             {{! `task` is null while we await }}
               {{#if task}}
-                Waiting for search <TaskStatus @task={{task}} @onTaskFinished={{this.refresh}} />
+                Waiting for search <TaskStatus @task={{task}} @onTaskFinished={{this.handleDeleteTaskFinished}} />
               {{/if}}
             {{/let}}
           {{else}}

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -31,9 +31,19 @@
         </td>
         <td>
           {{#if deleting}}
-            Deleting <TaskStatus @task={{await (vocab-get-deleting-task vocab)}} @onTaskFinished={{this.refresh}} />
+            {{#let (await (vocab-get-deleting-task vocab)) as | task |}}
+            {{! `task` is null while we await }}
+              {{#if task}}
+                Deleting <TaskStatus @task={{task}} @onTaskFinished={{this.refresh}} />
+              {{/if}}
+            {{/let}}
           {{else if waiting}}
-            Waiting for search <TaskStatus @task={{await (vocab-get-delete-waiting-task vocab)}} @onTaskFinished={{this.refresh}} />
+            {{#let (await (vocab-get-delete-waiting-task vocab)) as | task |}}
+            {{! `task` is null while we await }}
+              {{#if task}}
+                Waiting for search <TaskStatus @task={{task}} @onTaskFinished={{this.refresh}} />
+              {{/if}}
+            {{/let}}
           {{else}}
             <ConfirmationButton
               @onConfirm={{fn this.deleteVocab vocab}}

--- a/app/templates/vocabularies/index.hbs
+++ b/app/templates/vocabularies/index.hbs
@@ -31,9 +31,9 @@
         </td>
         <td>
           {{#if deleting}}
-            Deleting <TaskStatus @task={{await vocab.deletingTask}} @onTaskFinished={{action 'refresh'}} />
+            Deleting <TaskStatus @task={{await vocab.deletingTask}} @onTaskFinished={{this.refresh}} />
           {{else if waiting}}
-            Waiting for search <TaskStatus @task={{await vocab.deleteWaitingTask}} @onTaskFinished={{action 'refresh'}} />
+            Waiting for search <TaskStatus @task={{await vocab.deleteWaitingTask}} @onTaskFinished={{this.refresh}} />
           {{else}}
             <ConfirmationButton
               @onConfirm={{fn this.deleteVocab vocab}}

--- a/app/templates/vocabulary.hbs
+++ b/app/templates/vocabulary.hbs
@@ -3,23 +3,38 @@
   {{!-- TODO pr-2 is not working --}}
   <h1 class="px-2">Vocabulary: </h1>
   <h1>
-    <InlineEdit
-      @value={{this.model.name}}
-             @onSubmit={{this.updateVocabName}}
-    >{{this.model.name}}</InlineEdit>
+    {{#if (or (await this.model.deleting) (await this.model.deleteWaiting))}}
+      {{this.model.name}}
+    {{else}}
+      <InlineEdit
+        @value={{this.model.name}}
+               @onSubmit={{this.updateVocabName}}
+      >{{this.model.name}}</InlineEdit>
+    {{/if}}
   </h1>
 </div>
 <div>
-  <BsNav @type="tabs" as |nav|>
-    <nav.item>
-      <nav.link-to @route="vocabulary.index" @model={{this.model.id}}>Sources</nav.link-to>
-    </nav.item>
-    <nav.item>
-      <nav.link-to @route="vocabulary.mapping" @model={{this.model.id}}>Mapping</nav.link-to>
-    </nav.item>
-    <nav.item>
-      <nav.link-to @route="vocabulary.unification" @model={{this.model.id}}>Unification</nav.link-to>
-    </nav.item>
-  </BsNav>
-  {{outlet}}
+  {{#if (or (await this.model.deleting) (await this.model.deleteWaiting))}}
+    <BsAlert @type="danger" @dismissible={{false}}>
+      <:header>
+        This vocabulary is being deleted!
+      </:header>
+      <:body>
+        This vocabulary is being removed from the database!
+      </:body>
+    </BsAlert>
+  {{else}}
+    <BsNav @type="tabs" as |nav|>
+      <nav.item>
+        <nav.link-to @route="vocabulary.index" @model={{this.model.id}}>Sources</nav.link-to>
+      </nav.item>
+      <nav.item>
+        <nav.link-to @route="vocabulary.mapping" @model={{this.model.id}}>Mapping</nav.link-to>
+      </nav.item>
+      <nav.item>
+        <nav.link-to @route="vocabulary.unification" @model={{this.model.id}}>Unification</nav.link-to>
+      </nav.item>
+    </BsNav>
+    {{outlet}}
+  {{/if}}
 </div>

--- a/app/templates/vocabulary.hbs
+++ b/app/templates/vocabulary.hbs
@@ -3,7 +3,7 @@
   {{!-- TODO pr-2 is not working --}}
   <h1 class="px-2">Vocabulary: </h1>
   <h1>
-    {{#if (or (await this.model.deleting) (await this.model.deleteWaiting))}}
+    {{#if (or (await (vocab-is-deleting this.model)) (await (vocab-is-delete-waiting this.model)))}}
       {{this.model.name}}
     {{else}}
       <InlineEdit
@@ -14,7 +14,7 @@
   </h1>
 </div>
 <div>
-  {{#if (or (await this.model.deleting) (await this.model.deleteWaiting))}}
+  {{#if (or (await (vocab-is-deleting this.model)) (await (vocab-is-delete-waiting this.model)))}}
     <BsAlert @type="danger" @dismissible={{false}}>
       <:header>
         This vocabulary is being deleted!

--- a/app/templates/vocabulary/mapping.hbs
+++ b/app/templates/vocabulary/mapping.hbs
@@ -1,5 +1,5 @@
 {{page-title "Mapping"}}
-<BsAccordion as |acc|>
+<BsAccordion {{did-insert this.awaitMeta.perform }} as |acc|>
   <acc.item
     @value='1'
     @title='{{if


### PR DESCRIPTION
- show better feedback during deletion (also allowing a retry in case something failed).
- add sparql-query filter field in mapping and test button to test this filter (=> this has not been tested with large datasets yet, but any feedback is welcome)
- when analysis is "complete", the frontend still has to wait for the metadata to load before being able to show the analysis results and the mapping form. Now the page will reload automatically when the metadata is available.